### PR TITLE
Use click to run all 5 scripts in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## Census-Parquet Changelog
 -----------
 
-### Version 0.0.3 - 9/15/2021
-- Small Tweak to setup.py
+### Version 0.0.3 - 15 September 2021
+- Small tweak to setup.py
 
-### Version 0.0.2 - 9/15/2021
+### Version 0.0.2 - 15 September 2021
 - Created tagged release for PyPI
 
-### Version 0.0.1 - 9/15/2021
+### Version 0.0.1 - 15 September 2021
 - Initial release of processing scripts

--- a/README.md
+++ b/README.md
@@ -2,29 +2,34 @@
 Python tools for creating and maintaining Parquet files from [US 2020 Census Data](https://www.census.gov/programs-surveys/decennial-census/decade/2020/2020-census-main.html).
 
 
-## Install Dependencies
-These tools utilize several dependencies.
+## Installation
 
-To utilize the data download shell script files install [wget](https://en.wikipedia.org/wiki/Wget) and [lftp](https://en.wikipedia.org/wiki/Lftp).
+To use the data download shell script files first install [wget](https://en.wikipedia.org/wiki/Wget).
 
-For the python scripts the following dependencies should be installed:
-1. [dask](https://docs.dask.org/en/latest/install.html)
-2. [dask_geopandas](https://github.com/geopandas/dask-geopandas)
-3. [geopandas](https://geopandas.org/getting_started/install.html)
-4. [numpy](https://numpy.org/install/)
-5. [openpyxl](https://openpyxl.readthedocs.io/en/stable/#installation)
-6. [pandas](https://pandas.pydata.org/docs/getting_started/install.html)
-7. [pyarrow](https://arrow.apache.org/docs/python/install.html)
+To install the census-parquet package use
+```
+pip install census-parquet
+```
+
+This will also install the required Python dependencies which are:
+1. [click](https://github.com/pallets/click)
+2. [dask](https://docs.dask.org/en/latest/install.html)
+3. [dask_geopandas](https://github.com/geopandas/dask-geopandas)
+4. [geopandas](https://geopandas.org/getting_started/install.html)
+5. [numpy](https://numpy.org/install/)
+6. [openpyxl](https://openpyxl.readthedocs.io/en/stable/#installation)
+7. [pandas](https://pandas.pydata.org/docs/getting_started/install.html)
+8. [pyarrow](https://arrow.apache.org/docs/python/install.html)
 
 ## Usage
-The scripts should be run in the following order.
+To run the census-parquet code simply use
+```
+run_census_parquet
+```
 
-First, run the three shell scripts which download all the data needed for running the python scripts: 
+This runs the following scripts in order:
 1. `download_boundaries.sh` - This script downloads the Census Boundary data needed to run boundary_processing.py
 2. `download_population_stats.sh` - This script downloads population stat data needed for process_blocks.py
 3. `download_blocks.sh` - This script downloads the Census Block data needed to run process_blocks.py
-
-After running the shell scripts you can then run the python scripts:
-1. `boundary_processing.py` - This script processes the Census Boundary data and creates parquet files. The parquet files will be output into a `boundary_outputs` folder. 
-2. `process_blocks.py` - This script processes Census Block data and creates parquet files. The final combined parquet file will have the name `tl_2020_FULL_tabblock20.parquet`.
- 
+4. `boundary_processing.py` - This script processes the Census Boundary data and creates parquet files. The parquet files will be output into a `boundary_outputs` folder.
+5. `process_blocks.py` - This script processes Census Block data and creates parquet files. The final combined parquet file will have the name `tl_2020_FULL_tabblock20.parquet`.

--- a/census_parquet/boundary_processing.py
+++ b/census_parquet/boundary_processing.py
@@ -4,10 +4,11 @@ import geopandas as gpd
 import glob
 import os
 
+
 def load_dtype(filename):
     print(f'Started {filename}')
     gdf = gpd.read_file(filename, driver='SHP')
-    
+
     #dtype conversions
     mapping = {
         "AFFGEOID": "str",
@@ -71,21 +72,24 @@ def load_dtype(filename):
     }
     for name, dtype in mapping.items():
         try:
-            gdf[name] = gdf[name].astype(dtype, errors="ignore") 
+            gdf[name] = gdf[name].astype(dtype, errors="ignore")
         except KeyError:
             pass
-    
+
     #write to parquet
-    outputname = os.path.join(os.path.dirname(filename), 'boundary_outputs', os.path.splitext(os.path.split(filename)[-1])[0]+ '.parquet') 
+    outputname = os.path.join(os.path.dirname(filename), 'boundary_outputs', os.path.splitext(os.path.split(filename)[-1])[0]+ '.parquet')
     ddf = dask_geopandas.from_geopandas(gdf, npartitions=1)
     ddf.to_parquet(outputname)
     print(f'Finished {outputname}')
     return filename
-   
-if __name__ == '__main__':
+
+
+def main():
     files = glob.glob('./census_boundaries/*.zip')
     print(f'Found {len(files)} files')
     bg = bag.from_sequence(files).map(load_dtype)
     bg.compute()
-    
 
+
+if __name__ == '__main__':
+    main()

--- a/census_parquet/cli.py
+++ b/census_parquet/cli.py
@@ -1,11 +1,27 @@
 import click
+import os
+from subprocess import run
+import sys
+
+from . import boundary_processing, process_blocks
+
 
 @click.command()
 def start():
- """
- """
- print('CLI WORKING')
-  
-  
-if __name__ == '__main__':
- main()
+    """Download US 2020 Census Data and convert to parquet files."""
+    module_path = sys.modules['census_parquet'].__path__[0]
+
+    click.echo('Stage 1: Download boundaries')
+    run(os.path.join(module_path, 'download_boundaries.sh'))
+
+    click.echo('Stage 2: Download population stats')
+    run(os.path.join(module_path, 'download_population_stats.sh'))
+
+    click.echo('Stage 3: Download blocks')
+    run(os.path.join(module_path, 'download_blocks.sh'))
+
+    click.echo('Stage 4: Process boundaries')
+    boundary_processing.main()
+
+    click.echo('Stage 5: Process blocks')
+    process_blocks.main()

--- a/census_parquet/download_blocks.sh
+++ b/census_parquet/download_blocks.sh
@@ -1,1 +1,2 @@
-lftp -c 'mirror --parallel=100 https://www2.census.gov/geo/tiger/TIGER2020/TABBLOCK20/ ;exit'
+#!/bin/bash
+wget -w 0.5 -c -r -np -nH -nv -e robots=off -R "index.html*" --cut-dirs=3 https://www2.census.gov/geo/tiger/TIGER2020/TABBLOCK20/

--- a/census_parquet/download_boundaries.sh
+++ b/census_parquet/download_boundaries.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 mkdir -p census_boundaries
-cd census_boundaries 
+cd census_boundaries
 wget https://www2.census.gov/geo/tiger/GENZ2020/shp/cb_2020_us_all_500k.zip
 unzip cb_2020_us_all_500k.zip
-rm cb_2020_us_all_500k.zip 
+rm cb_2020_us_all_500k.zip

--- a/census_parquet/download_population_stats.sh
+++ b/census_parquet/download_population_stats.sh
@@ -1,4 +1,5 @@
-lftp -c 'mirror --parallel=100 https://www2.census.gov/programs-surveys/decennial/2020/data/01-Redistricting_File--PL_94-171/ ;exit'
+#!/bin/bash
+wget -w 0.5 -r -np -nH -nv -e robots=off -R "index.html*" --cut-dirs=4 https://www2.census.gov/programs-surveys/decennial/2020/data/01-Redistricting_File--PL_94-171/
 mkdir -p population_stats
 find 01-Redistricting_File--PL_94-171 -name '*.pl.zip' -exec mv {} ./population_stats \;
 find ./population_stats -name '*.pl.zip' -execdir unzip {} \;

--- a/census_parquet/process_blocks.py
+++ b/census_parquet/process_blocks.py
@@ -136,8 +136,12 @@ def combine_parquet_files(input_folder, target_path):
         raise
 
 
-if __name__ == '__main__':
+def main():
     files = glob.glob('./TABBLOCK20/*.zip')
     bg = bag.from_sequence(files).map(load)
     bg.compute()
     combine_parquet_files('./outputs', 'tl_2020_FULL_tabblock20.parquet')
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ setup(
     version='0.0.3',
     packages=['census_parquet'],
     license='MIT',
-    description='Tools for generating Parquet files from Census 2020',
+    description='Tools for generating Parquet files from US Census 2020',
     author='makepath',
     url='https://github.com/makepath/census-parquet',
-     entry_points={
+    entry_points={
         'console_scripts': ['run_census_parquet=census_parquet.cli:start']
     },
     install_requires=[
-        'Click',
+        'click',
         'dask_geopandas',
         'openpyxl',
         'pyarrow',


### PR DESCRIPTION
Use Python `click` to run all 5 scripts in order using the single command `run_census_parquet`.
Also replaced use of `lftp` with `wget` with a 0.5 second delay between download files to avoid download problems.